### PR TITLE
Fix pattern match for :disksup.get_disk_data()

### DIFF
--- a/lib/nerves_hub_link/extensions/health/metric_set/disk.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/disk.ex
@@ -33,7 +33,7 @@ defmodule NervesHubLink.Extensions.Health.MetricSet.Disk do
     # returns the available disk space in KB so we don't have
     # to calculate it ourselves.
     data =
-      Enum.find(:disksup.get_disk_data(), fn {key, _, _, _} ->
+      Enum.find(:disksup.get_disk_data(), fn {key, _, _} ->
         key == ~c"/root"
       end)
 


### PR DESCRIPTION
[:disksup.get_disk_data()](https://www.erlang.org/doc/apps/os_mon/disksup.html#get_disk_data/0) returns {key, total, capacity_percentage} so the current pattern match is broken.